### PR TITLE
Hardcoded `.output/public` causing issues on Netlify

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -23,11 +23,8 @@ export async function generateSitemaps(options, globalCache, nuxtInstance, depth
     logger.warn("A sitemap index file can't list other sitemap index files, but only sitemap files")
   }
 
-  if (!nuxtInstance.options.generate?.dir) {
-    nuxtInstance.options.generate.dir = nuxtInstance.options.srcDir
-  }
-
-  const publicDir = path.relative(nuxtInstance.options.generate.dir, nuxtInstance._nitro.options.output.publicDir)
+  const publicDir =
+    nuxtInstance._nitro.options.output.publicDir ?? path.join(nuxtInstance.options.srcDir, '.output/public')
 
   const isSitemapIndex = options && options.sitemaps && Array.isArray(options.sitemaps) && options.sitemaps.length > 0
 
@@ -59,15 +56,15 @@ export async function generateSitemap(options, globalCache, nuxtInstance, depth 
   const routes = await cache.routes.get('routes')
   const base = nuxtInstance.options.router.base
   const sitemap = await createSitemap(options, routes, base)
-  const xmlFilePath = path.join(nuxtInstance.options.generate.dir, publicDir, options.path)
+  const xmlFilePath = path.join(publicDir, options.path)
   fs.outputFileSync(xmlFilePath, sitemap.toXML())
-  logger.success('Generated', getPathname(nuxtInstance.options.generate.dir, xmlFilePath))
+  logger.success('Generated', getPathname(nuxtInstance.options.srcDir, xmlFilePath))
 
   // Generate sitemap.xml.gz
   if (options.gzip) {
-    const gzipFilePath = path.join(nuxtInstance.options.generate.dir, publicDir, options.pathGzip)
+    const gzipFilePath = path.join(publicDir, options.pathGzip)
     fs.outputFileSync(gzipFilePath, sitemap.toGzip())
-    logger.success('Generated', getPathname(nuxtInstance.options.generate.dir, gzipFilePath))
+    logger.success('Generated', getPathname(nuxtInstance.options.srcDir, gzipFilePath))
   }
 }
 
@@ -86,16 +83,16 @@ export async function generateSitemapIndex(options, globalCache, nuxtInstance, d
   // Generate sitemapindex.xml
   const base = nuxtInstance.options.router.base
   const xml = createSitemapIndex(options, base)
-  const xmlFilePath = path.join(nuxtInstance.options.generate.dir, publicDir, options.path)
+  const xmlFilePath = path.join(publicDir, options.path)
   fs.outputFileSync(xmlFilePath, xml)
-  logger.success('Generated', getPathname(nuxtInstance.options.generate.dir, xmlFilePath))
+  logger.success('Generated', getPathname(nuxtInstance.options.srcDir, xmlFilePath))
 
   // Generate sitemapindex.xml.gz
   if (options.gzip) {
     const gzip = gzipSync(xml)
-    const gzipFilePath = path.join(nuxtInstance.options.generate.dir, publicDir, options.pathGzip)
+    const gzipFilePath = path.join(publicDir, options.pathGzip)
     fs.outputFileSync(gzipFilePath, gzip)
-    logger.success('Generated', getPathname(nuxtInstance.options.generate.dir, gzipFilePath))
+    logger.success('Generated', getPathname(nuxtInstance.options.srcDir, gzipFilePath))
   }
 
   // Generate linked sitemaps

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -27,7 +27,7 @@ export async function generateSitemaps(options, globalCache, nuxtInstance, depth
     nuxtInstance.options.generate.dir = nuxtInstance.options.srcDir
   }
 
-  const publicDir = '/.output/public'
+  const publicDir = path.relative(nuxtInstance.options.generate.dir, nuxtInstance._nitro.options.output.publicDir)
 
   const isSitemapIndex = options && options.sitemaps && Array.isArray(options.sitemaps) && options.sitemaps.length > 0
 


### PR DESCRIPTION
Hey!

I've run into some issues with this module when deploying a statically generated Nuxt app (using `nuxt generate`) to Netlify.

This module seems to assume that the output dir is always `.output/public` in the Nuxt source directory, because sitemaps are always basically written to `path.join(nuxtInstance.options.srcDir, '.output/public)`, but Nitro recognizes Netlify (probably by checking `process.env.NETLIFY`), sets `NITRO_PRESET` to `netlify` and that changes the output directory to `dist` instead of `.output/public`. I tried to fix this in a PR, but I'm still getting some failing tests.

Could you look into this? Consider my PR just an experiment, I'm not a very experienced open source dev :sweat_smile:.

You can mimic Nitro's behavior on Netlify by running `NITRO_PRESET=netlify yarn build-module`. If ran, the current tests fail too.