### PR TITLE
Export TypeScript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "type": "module",
   "main": "dist/module.cjs",
   "module": "dist/module.mjs",
+  "types": "dist/types.d.ts",
   "scripts": {
     "build-module": "nuxt-build-module && yarn unit",
     "build": "npx nuxi build test/fixture",

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -2,21 +2,24 @@ import path from 'path'
 import { gzipSync } from 'zlib'
 // eslint-disable-next-line import/default
 import fs from 'fs-extra'
+import type { Nuxt } from '@nuxt/schema'
 import { createSitemap, createSitemapIndex } from './runtime/builder'
 import { createRoutesCache } from './runtime/cache'
 import logger from './runtime/logger'
 import { setDefaultSitemapIndexOptions, setDefaultSitemapOptions } from './options'
 import { excludeRoutes } from './runtime/routes'
+import { ModuleOptions, SitemapIndexOptions, SitemapOptions, GlobalCache } from './module'
+import { isSitemapIndex } from './helpers'
 
 /**
  * Generate a static file for each sitemap or sitemapindex
- *
- * @param {Object} options
- * @param {Object} globalCache
- * @param {Nuxt}   nuxtInstance
- * @param {number} depth
  */
-export async function generateSitemaps(options, globalCache, nuxtInstance, depth = 0) {
+export async function generateSitemaps(
+  options: ModuleOptions,
+  globalCache: GlobalCache,
+  nuxtInstance: Nuxt,
+  depth = 0
+): Promise<void> {
   /* istanbul ignore if */
   if (depth > 1) {
     // see https://webmasters.stackexchange.com/questions/18243/can-a-sitemap-index-contain-other-sitemap-indexes
@@ -29,9 +32,7 @@ export async function generateSitemaps(options, globalCache, nuxtInstance, depth
 
   const publicDir = '/.output/public'
 
-  const isSitemapIndex = options && options.sitemaps && Array.isArray(options.sitemaps) && options.sitemaps.length > 0
-
-  if (isSitemapIndex) {
+  if (isSitemapIndex(options)) {
     await generateSitemapIndex(options, globalCache, nuxtInstance, depth, publicDir)
   } else {
     await generateSitemap(options, globalCache, nuxtInstance, depth, publicDir)
@@ -40,13 +41,14 @@ export async function generateSitemaps(options, globalCache, nuxtInstance, depth
 
 /**
  * Generate a sitemap file
- *
- * @param {Object} options
- * @param {Object} globalCache
- * @param {Nuxt}   nuxtInstance
- * @param {number} depth
  */
-export async function generateSitemap(options, globalCache, nuxtInstance, depth = 0, publicDir) {
+export async function generateSitemap(
+  options: SitemapOptions,
+  globalCache: GlobalCache,
+  nuxtInstance: Nuxt,
+  depth = 0,
+  publicDir: string
+): Promise<void> {
   // Init options
   options = setDefaultSitemapOptions(options, nuxtInstance, depth > 0)
 
@@ -73,13 +75,14 @@ export async function generateSitemap(options, globalCache, nuxtInstance, depth 
 
 /**
  * Generate a sitemapindex file
- *
- * @param {Object} options
- * @param {Object} globalCache
- * @param {Nuxt}   nuxtInstance
- * @param {number} depth
  */
-export async function generateSitemapIndex(options, globalCache, nuxtInstance, depth = 0, publicDir) {
+export async function generateSitemapIndex(
+  options: SitemapIndexOptions,
+  globalCache: GlobalCache,
+  nuxtInstance: Nuxt,
+  depth = 0,
+  publicDir: string
+): Promise<void> {
   // Init options
   options = setDefaultSitemapIndexOptions(options, nuxtInstance)
 
@@ -106,11 +109,7 @@ export async function generateSitemapIndex(options, globalCache, nuxtInstance, d
 
 /**
  * Convert a file path to a URL pathname
- *
- * @param   {string} dirPath
- * @param   {string} filePath
- * @returns {string}
  */
-function getPathname(dirPath, filePath) {
+function getPathname(dirPath: string, filePath: string): string {
   return [, ...path.relative(dirPath, filePath).split(path.sep)].join('/')
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,5 @@
+import { SitemapIndexOptions, SitemapOptions } from './module'
+
+export function isSitemapIndex(options: SitemapOptions | SitemapIndexOptions): options is SitemapIndexOptions {
+  return options && 'sitemaps' in options && Array.isArray(options.sitemaps) && options.sitemaps.length > 0
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,25 +1,26 @@
+import type { Nuxt } from '@nuxt/schema'
 import { addServerHandler, createResolver } from '@nuxt/kit'
 import logger from './runtime/logger'
 import { setDefaultSitemapIndexOptions, setDefaultSitemapOptions } from './options'
+import type { SitemapOptions, SitemapIndexOptions, GlobalCache } from './module'
+import { isSitemapIndex } from './helpers'
 
 /**
  * Register a middleware for each sitemap or sitemapindex
- *
- * @param {Object} options
- * @param {Object} globalCache
- * @param {Nuxt}   nuxtInstance
- * @param {number} depth
  */
-export function registerSitemaps(options, globalCache, nuxtInstance, depth = 0) {
+export function registerSitemaps(
+  options: SitemapOptions | SitemapIndexOptions,
+  globalCache: GlobalCache,
+  nuxtInstance: Nuxt,
+  depth = 0
+) {
   /* istanbul ignore if */
   if (depth > 1) {
     // see https://webmasters.stackexchange.com/questions/18243/can-a-sitemap-index-contain-other-sitemap-indexes
     logger.warn("A sitemap index file can't list other sitemap index files, but only sitemap files")
   }
 
-  const isSitemapIndex = options && options.sitemaps && Array.isArray(options.sitemaps) && options.sitemaps.length > 0
-
-  if (isSitemapIndex) {
+  if (isSitemapIndex(options)) {
     registerSitemapIndex(options, globalCache, nuxtInstance, depth)
   } else {
     registerSitemap(options, globalCache, nuxtInstance, depth)
@@ -28,13 +29,8 @@ export function registerSitemaps(options, globalCache, nuxtInstance, depth = 0) 
 
 /**
  * Register a middleware to serve a sitemap
- *
- * @param {Object} options
- * @param {Object} globalCache
- * @param {Nuxt}   nuxtInstance
- * @param {number} depth
  */
-export function registerSitemap(options, globalCache, nuxtInstance, depth = 0) {
+export function registerSitemap(options: SitemapOptions, globalCache: GlobalCache, nuxtInstance: Nuxt, depth = 0) {
   // Init options
   options = setDefaultSitemapOptions(options, nuxtInstance, depth > 0)
   options = prepareOptionPaths(options, nuxtInstance)
@@ -64,13 +60,13 @@ export function registerSitemap(options, globalCache, nuxtInstance, depth = 0) {
 
 /**
  * Register a middleware to serve a sitemapindex
- *
- * @param {Object} options
- * @param {Object} globalCache
- * @param {Nuxt}   nuxtInstance
- * @param {number} depth
  */
-export function registerSitemapIndex(options, globalCache, nuxtInstance, depth = 0) {
+export function registerSitemapIndex(
+  options: SitemapIndexOptions,
+  globalCache: GlobalCache,
+  nuxtInstance: Nuxt,
+  depth = 0
+) {
   // Init options
   options = setDefaultSitemapIndexOptions(options, nuxtInstance)
   options = prepareOptionPaths(options, nuxtInstance)
@@ -100,7 +96,7 @@ export function registerSitemapIndex(options, globalCache, nuxtInstance, depth =
   options.sitemaps.forEach((sitemapOptions) => registerSitemaps(sitemapOptions, globalCache, nuxtInstance, depth + 1))
 }
 
-function prepareOptionPaths(options, nuxtInstance) {
+function prepareOptionPaths<T extends SitemapOptions | SitemapIndexOptions>(options: T, nuxtInstance: Nuxt): T {
   options.base = nuxtInstance.options.app.baseURL || '/'
   options.path = options.base !== '/' || options.path.startsWith('/') ? options.path : '/' + options.path
   options.pathGzip =

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,3 +1,5 @@
+import type { Nuxt } from '@nuxt/schema'
+import type { SitemapIndexOptions, SitemapOptions } from './module'
 import logger from './runtime/logger'
 
 const MODULE_NAME = 'Nuxt 3 Sitemap Module'
@@ -5,14 +7,13 @@ const DEFAULT_NUXT_PUBLIC_PATH = '/_nuxt/'
 
 /**
  * Set default options for a sitemap config
- *
- * @param   {Object}  options
- * @param   {Nuxt}    nuxtInstance
- * @param   {boolean} isLinkedToSitemapIndex
- * @returns {Object}
  */
-export function setDefaultSitemapOptions(options, nuxtInstance, isLinkedToSitemapIndex = false) {
-  const defaults = {
+export function setDefaultSitemapOptions(
+  options: SitemapOptions,
+  nuxtInstance: Nuxt,
+  isLinkedToSitemapIndex = false
+): SitemapOptions {
+  const defaults: SitemapOptions = {
     path: '/sitemap.xml',
     hostname:
       // TODO: remove support of "build.publicPath" on release 3.0
@@ -35,7 +36,7 @@ export function setDefaultSitemapOptions(options, nuxtInstance, isLinkedToSitema
     base: '/',
   }
 
-  const sitemapOptions = {
+  const sitemapOptions: SitemapOptions = {
     ...defaults,
     ...options,
   }
@@ -86,13 +87,9 @@ export function setDefaultSitemapOptions(options, nuxtInstance, isLinkedToSitema
 
 /**
  * Set default options for a sitemapindex config
- *
- * @param   {Object} options
- * @param   {Nuxt}   nuxtInstance
- * @returns {Object}
  */
-export function setDefaultSitemapIndexOptions(options, nuxtInstance) {
-  const defaults = {
+export function setDefaultSitemapIndexOptions(options: SitemapIndexOptions, nuxtInstance: Nuxt): SitemapIndexOptions {
+  const defaults: SitemapIndexOptions = {
     path: '/sitemapindex.xml',
     hostname: undefined,
     sitemaps: [],
@@ -104,7 +101,7 @@ export function setDefaultSitemapIndexOptions(options, nuxtInstance) {
     base: '/',
   }
 
-  const sitemapIndexOptions = {
+  const sitemapIndexOptions: SitemapIndexOptions = {
     ...defaults,
     ...options,
   }

--- a/test/fixture/nuxt.config.js
+++ b/test/fixture/nuxt.config.js
@@ -1,4 +1,5 @@
-module.exports = {
+// eslint-disable-next-line no-undef
+module.exports = defineNuxtConfig({
   srcDir: __dirname,
   render: {
     resourceHints: false,
@@ -43,4 +44,4 @@ module.exports = {
       ],
     },
   ],
-}
+})


### PR DESCRIPTION
I noticed TS displaying errors when adding the `sitemap` property to your nuxt config when wrapped in `defineNuxtConfig()`. I decided to take a look and noticed this module doesn't expose any TS types yet. I made a first attempt, but I'm not very familiar with this codebase, so there's probably still a lot wrong with it. I haven't fully tested this in an actual Nuxt project yet either. Hopefully this is still helpful though :smile:.